### PR TITLE
Adding #[\AllowDynamicProperties] for php 8.2 and up

### DIFF
--- a/Zebra_Session.php
+++ b/Zebra_Session.php
@@ -14,6 +14,7 @@
  *  @license    https://www.gnu.org/licenses/lgpl-3.0.txt GNU LESSER GENERAL PUBLIC LICENSE
  *  @package    Zebra_Session
  */
+#[\AllowDynamicProperties]
 class Zebra_Session {
 
     /**


### PR DESCRIPTION
Simply adding #[\AllowDynamicProperties] to remove deprecation notices in php 8.2 and up